### PR TITLE
BUG: m_Alpha and m_Sigma are private variables

### DIFF
--- a/test/RotateLabels.cxx
+++ b/test/RotateLabels.cxx
@@ -118,8 +118,8 @@ template<class TImage,typename TCoordRep> class FixedGaussianInterpolator : publ
   itkNewMacro( Self );
   FixedGaussianInterpolator()
   {
-    this->m_Alpha = 1.0;
-    this->m_Sigma.Fill(0.3);
+    this->SetAlpha(1.0);
+    this->SetSigma(0.3);
   }
 };
  


### PR DESCRIPTION
FixedGaussianInterpolator was trying to set m_Alpha and m_Sigma
without using the 'Set' functions to do so. But m_Alpha and m_Sigma
are private variables declared in itk::GaussianInterpolateImageFunction
which is the parent class of FixedGaussianInterpolator.
