### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkLabelImageGenericInterpolateImageFunction.h
+++ b/include/itkLabelImageGenericInterpolateImageFunction.h
@@ -42,6 +42,8 @@ class ITK_EXPORT LabelImageGenericInterpolateImageFunction :
   public InterpolateImageFunction<TInputImage, TCoordRep>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(LabelImageGenericInterpolateImageFunction);
+
   /** Standard class type alias. */
   using Self = LabelImageGenericInterpolateImageFunction;
   using Superclass = InterpolateImageFunction<TInputImage, TCoordRep>;
@@ -99,9 +101,6 @@ protected:
   LabelSetType m_Labels;
 
 private:
-  LabelImageGenericInterpolateImageFunction( const Self& ); //purposely not implemented
-  void operator=( const Self& ); //purposely not implemented
-
   /**
    * Evaluate function value at the given index
    */

--- a/include/itkLabelSelectionImageAdaptor.h
+++ b/include/itkLabelSelectionImageAdaptor.h
@@ -40,6 +40,8 @@ class ITK_EXPORT LabelSelectionImageAdaptor:public
                   TOutputPixelType >   >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(LabelSelectionImageAdaptor);
+
   /** Standard class type alias. */
   using Self = LabelSelectionImageAdaptor;
   using Superclass = ImageAdaptor< TImage, Accessor::LabelSelectionPixelAccessor<
@@ -62,10 +64,6 @@ public:
 protected:
   LabelSelectionImageAdaptor() {}
   ~LabelSelectionImageAdaptor() override {}
-
-private:
-  LabelSelectionImageAdaptor(const Self &); //purposely not implemented
-  void operator=(const Self &);  //purposely not implemented
 };
 } // end namespace itk
 


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.