### PR TITLE
DOC: Improve the module documentation.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,17 +1,46 @@
-GenericLabelInterpolator
-========================
+ITKGenericLabelInterpolator
+===========================
 
-.. image:: https://circleci.com/gh/fbudin69500/ITKGenericLabelInterpolator/tree/master.svg?style=svg
-    :target: https://circleci.com/gh/fbudin69500/ITKGenericLabelInterpolator/tree/master
+.. |CircleCI| image:: https://circleci.com/gh/InsightSoftwareConsortium/ITKGenericLabelInterpolator.svg?style=shield
+    :target: https://circleci.com/gh/InsightSoftwareConsortium/ITKGenericLabelInterpolator
 
-The basic idea of this generic interpolator for label images is to interpolate each label with an ordinary image interpolator, and return the label with the highest value. This is the idea used by the itk::LabelImageGaussianInterpolateImageFunction interpolator. Unfortunately, this class is currently limited to Gaussian interpolation. Using generic programming, our proposed interpolator extends this idea to any image interpolator. Combined with linear interpolation, this results in similar or better accuracy and much improved computation speeds on a test image.
+.. |TravisCI| image:: https://travis-ci.org/InsightSoftwareConsortium/ITKGenericLabelInterpolator.svg?branch=master
+    :target: https://travis-ci.org/InsightSoftwareConsortium/ITKGenericLabelInterpolator
 
-A more detailed description can be found in the Insight Journal article::
+.. |AppVeyor| image:: https://img.shields.io/appveyor/ci/itkrobot/itkgenericlabelinterpolator.svg
+    :target: https://ci.appveyor.com/project/itkrobot/itkgenericlabelinterpolator
 
-  Schaerer, J., Roche, F., Belaroussi, B. \"A generic interpolator for multi-label images\".
-    http://hdl.handle.net/10380/3506
-    http://www.insight-journal.org/browse/publication/950
-    December, 2014.
+=========== =========== ===========
+   Linux      macOS       Windows
+=========== =========== ===========
+|CircleCI|  |TravisCI|  |AppVeyor|
+=========== =========== ===========
+
+
+Overview
+--------
+
+This is a module for the `Insight Toolkit (ITK) <http://itk.org>`_ that
+provides a generic interpolator for label images to interpolate each label
+with an ordinary image interpolator, and return the label with the highest
+value. This is the idea used by the
+`itk::LabelImageGaussianInterpolateImageFunction` interpolator. Unfortunately,
+this class is currently limited to Gaussian interpolation. Using generic
+programming, the proposed interpolator extends this idea to any image
+interpolator. Combined with linear interpolation, this results in similar or
+better accuracy and much improved computation speeds on a test image.
+
+For more information, see the `Insight Journal article <http://hdl.handle.net/10380/3506>`_::
+
+  Schaerer, J., Roche, F., Belaroussi, B.
+  A generic interpolator for multi-label images
+  The Insight Journal. January-December, 2014.
+  http://hdl.handle.net/10380/3506
+  http://www.insight-journal.org/browse/publication/950
+
+
+Installation
+------------
 
 Since ITK 4.10.0, this module is available in the ITK source tree as a Remote
 module.  To enable it, set::
@@ -19,3 +48,10 @@ module.  To enable it, set::
   Module_GenericLabelInterpolator:BOOL=ON
 
 in ITK's CMake build configuration.
+
+
+License
+-------
+
+This software is distributed under the Apache 2.0 license. Please see the
+*LICENSE* file for details.

--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -1,13 +1,14 @@
-set(DOCUMENTATION "The basic idea of this generic interpolator for label images is to interpolate each label with an ordinary image interpolator, and return the label with the highest value. This is the idea used by the itk::LabelImageGaussianInterpolateImageFunction interpolator. Unfortunately, this class is currently limited to Gaussian interpolation. Using generic programming, our proposed interpolator extends this idea to any image interpolator. Combined with linear interpolation, this results in similar or better accuracy and much improved computation speeds on a test image.
+# the top-level README is used for describing this module, just
+# re-used it for documentation here
+get_filename_component(MY_CURENT_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+file(READ "${MY_CURENT_DIR}/README.rst" DOCUMENTATION)
 
-A more detailed description can be found in the Insight Journal article::
+# itk_module() defines the module dependencies in GenericLabelInterpolator
+# The testing module in GenericLabelInterpolator depends on ITKTestKernel
+# By convention those modules outside of ITK are not prefixed with
+# ITK
 
-Schaerer, J., Roche, F., Belaroussi, B. \"A generic interpolator for multi-label images\".
-  http://hdl.handle.net/10380/3506
-  http://www.insight-journal.org/browse/publication/950
-  December, 2014.
-")
-
+# define the dependencies of the include module and the tests
 itk_module(GenericLabelInterpolator
   DEPENDS
     ITKSmoothing


### PR DESCRIPTION
Improve the `README.rst` file style, and conform to the
ITKModuleTemplate conventions:

- Use the remote module project name as the title.
- Place the CI badges in a table.
- Divide the file into sections.
- Improve the IJ citation to conform to common format.
- Cross-reference the LICENSE file.
- New line at 80 characters.

Re-use the `README.rst` file documentation for the `itk-module.cmake` file
documentation.