### PR TITLE
COMP: parameter using 'typename' is a C++17 extension

### DIFF
--- a/include/itkLabelImageGenericInterpolateImageFunction.h
+++ b/include/itkLabelImageGenericInterpolateImageFunction.h
@@ -37,7 +37,7 @@ namespace itk
  * * \ingroup GenericLabelInterpolator
  */
 
-template <typename TInputImage,template<typename, typename> typename TInterpolator, typename TCoordRep=double >
+template <typename TInputImage,template<typename, typename> class TInterpolator, typename TCoordRep=double >
 class ITK_EXPORT LabelImageGenericInterpolateImageFunction :
   public InterpolateImageFunction<TInputImage, TCoordRep>
 {

--- a/include/itkLabelImageGenericInterpolateImageFunction.hxx
+++ b/include/itkLabelImageGenericInterpolateImageFunction.hxx
@@ -24,7 +24,7 @@
 namespace itk
 {
 
-template<typename TInputImage, template<typename, typename> typename TInterpolator , typename TCoordRep>
+template<typename TInputImage, template<typename, typename> class TInterpolator , typename TCoordRep>
 void LabelImageGenericInterpolateImageFunction<TInputImage,TInterpolator, TCoordRep>
 ::SetInputImage( const TInputImage *image ) {
   /* We have one adaptor and one interpolator per label to keep the class thread-safe:
@@ -55,7 +55,7 @@ void LabelImageGenericInterpolateImageFunction<TInputImage,TInterpolator, TCoord
   Superclass::SetInputImage(image);
 }
 
-template<typename TInputImage, template<typename, typename> typename TInterpolator , typename TCoordRep>
+template<typename TInputImage, template<typename, typename> class TInterpolator , typename TCoordRep>
 typename LabelImageGenericInterpolateImageFunction<TInputImage, TInterpolator, TCoordRep>
 ::OutputType
 LabelImageGenericInterpolateImageFunction<TInputImage, TInterpolator, TCoordRep>


### PR DESCRIPTION
In file included from GenericLabelInterpolator/include/itkLabelImageGenericInterpolateImageFunction.h:127:
GenericLabelInterpolator/include/itkLabelImageGenericInterpolateImageFunction.hxx:27:61: warning: template template
      parameter using 'typename' is a C++17 extension [-Wc++17-extensions]
template<typename TInputImage, template<typename, typename> typename TInterpolator , typename TCoordRep>
                                                            ^~~~~~~~
                                                            class
template<typename TInputImage, template<typename, typename> typename TInterpolator , typename TCoordRep>
                                                            ^~~~~~~~
                                                            class