### PR TITLE
STYLE: Rename ITK_DISALLOW_COPY_AND_ASSIGN to ITK_DISALLOW_COPY_AND_MOVE

### DIFF
--- a/include/itkLabelImageGenericInterpolateImageFunction.h
+++ b/include/itkLabelImageGenericInterpolateImageFunction.h
@@ -41,7 +41,7 @@ template <typename TInputImage, template <typename, typename> class TInterpolato
 class ITK_EXPORT LabelImageGenericInterpolateImageFunction : public InterpolateImageFunction<TInputImage, TCoordRep>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(LabelImageGenericInterpolateImageFunction);
+  ITK_DISALLOW_COPY_AND_MOVE(LabelImageGenericInterpolateImageFunction);
 
   /** Standard class type alias. */
   using Self = LabelImageGenericInterpolateImageFunction;

--- a/include/itkLabelSelectionImageAdaptor.h
+++ b/include/itkLabelSelectionImageAdaptor.h
@@ -37,7 +37,7 @@ class ITK_EXPORT LabelSelectionImageAdaptor
   : public ImageAdaptor<TImage, Accessor::LabelSelectionPixelAccessor<typename TImage::PixelType, TOutputPixelType>>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(LabelSelectionImageAdaptor);
+  ITK_DISALLOW_COPY_AND_MOVE(LabelSelectionImageAdaptor);
 
   /** Standard class type alias. */
   using Self = LabelSelectionImageAdaptor;


### PR DESCRIPTION
This PR fixes changes made in [#2053](https://github.com/InsightSoftwareConsortium/ITK/pull/2053/commits/4eac1a0cfb456fad1e3894173a41d7c7de49b08f). Essentially, `ITK_DISALLOW_COPY_AND_ASSIGN` has been changed to `ITK_DISALLOW_COPY_AND_MOVE` to more accurately convey the actions taking place. `ITK_DISALLOW_COPY_AND_ASSIGN` will **only** be used if `ITK_FUTURE_LEGACY_REMOVE=OFF`.

**NOTE:** These changes will cause the GitHub Actions to break, because they currently build `ITK v5.1.0`. The errors persist with `v5.1.1` as well (will update to newest version in separate PR). When tested locally against `master`, I get all tests to pass. The case is the same for the remaining 39 remote modules.