### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkLabelImageGenericInterpolateImageFunction.hxx
+++ b/include/itkLabelImageGenericInterpolateImageFunction.hxx
@@ -18,7 +18,6 @@
 #ifndef itkLabelImageGenericInterpolateImageFunction_hxx
 #define itkLabelImageGenericInterpolateImageFunction_hxx
 
-#include "itkLabelImageGenericInterpolateImageFunction.h"
 #include <itkImageRegionConstIterator.h>
 
 namespace itk


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

